### PR TITLE
Simplify fuzzing code

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+artifacts
+corpus
+coverage


### PR DESCRIPTION
This PR tries to simplify the fuzzing code a little by accepting a `Vec` with key, value pairs instead of a byte slice that has to be manually processed. The original harness also only had both the key and value be of a set max length, while this one doesn't have that limitation. The runs can be seen [here](https://mayhem.forallsecure.com/ysthakur/rust-kv). Unfortunately, it's rather slow (first run was 95.8 tests per second). I'm assuming the original harness was also this slow, though.